### PR TITLE
Don't invalidate session on return

### DIFF
--- a/src/Controller/SSOReturnController.php
+++ b/src/Controller/SSOReturnController.php
@@ -158,7 +158,6 @@ final class SSOReturnController extends Controller
             'Invalidate current state and redirect user to service provider assertion consumer url "%s"',
             $acu
         ));
-        $this->stateHandler->invalidate();
 
         return $response;
     }

--- a/src/Resources/views/StepupGssp/ssoReturn.html.twig
+++ b/src/Resources/views/StepupGssp/ssoReturn.html.twig
@@ -12,7 +12,7 @@
 
 {% block body %}
     {{ 'gssp.sso_return.one_moment_please'|trans }}
-    </br>
+    <br/>
     <noscript>
         {{ 'gssp.sso_return.js_disabled'|trans }}
     </noscript>


### PR DESCRIPTION
This fixes the refresh or locale changes on the SSO return endpoint. 

- Storing the SAML response locally inside a query parameter does not improve security


