### PR TITLE
Use assertion NotOnOrAfter for SubjectConfirmation validity

### DIFF
--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -73,7 +73,7 @@ final class ResponseService implements ResponseServiceInterface
         $confirmationData = new SubjectConfirmationData();
         $confirmationData->InResponseTo = $this->responseContext->getRequestId();
         $confirmationData->Recipient = $this->responseContext->getServiceProvider()->getAssertionConsumerUrl();
-        $confirmationData->NotOnOrAfter = $this->dateTimeService->interval('PT8H')->getTimestamp();
+        $confirmationData->NotOnOrAfter = $assertion->getNotOnOrAfter();
 
         $confirmation->SubjectConfirmationData = $confirmationData;
 

--- a/tests/Service/fixture/saml_response.xml
+++ b/tests/Service/fixture/saml_response.xml
@@ -9,7 +9,7 @@
         <saml:Subject>
             <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">subject_name_id</saml:NameID>
             <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-                <saml:SubjectConfirmationData InResponseTo="sp_request_id" NotOnOrAfter="2016-12-08T17:42:59Z" Recipient="https://service_provider/saml/acu"/>
+                <saml:SubjectConfirmationData InResponseTo="sp_request_id" NotOnOrAfter="2016-12-08T09:47:59Z" Recipient="https://service_provider/saml/acu"/>
             </saml:SubjectConfirmation>
         </saml:Subject>
         <saml:Conditions NotBefore="2016-12-08T09:42:59Z" NotOnOrAfter="2016-12-08T09:47:59Z">

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,1 +1,2 @@
 date.timezone = "Europe/Amsterdam"
+memory_limit = 2048M


### PR DESCRIPTION
The SAML spec states the NotOnOrAfter of a subject confirmation should
not exceed the value of the assertions NotOnOrAfter. Gateway now uses
the assertion NotOnOrAfter value of SubjectConfirmation, instead of a
timestamp 8 hours in the future. The NotOnOrAfter is now always 5
minutes after generating the response.

See https://www.pivotaltracker.com/story/show/158356792