### PR TITLE
Fix: Behat tests fail with signature validation errors

### DIFF
--- a/src/Features/Context/GsspContext.php
+++ b/src/Features/Context/GsspContext.php
@@ -528,7 +528,7 @@ final class GsspContext implements Context
      */
     private static function loadPublicKey($publicKey)
     {
-        $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, ['type' => 'public']);
+        $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'public']);
         $key->loadKey($publicKey, true);
 
         return $key;


### PR DESCRIPTION
Since simplesamlphp/saml2 3.2.0 RSA_SHA256 is the default, this somehow breaks verification with a key that is loaded with RSA_SHA1, where this worked before.
Because all signatures should in fact be signed using RSA SHA-265, we should use that. This works with saml2 version before 3.2.0 as well.
Tested with surfnet/stepup-saml-bundle 4.1.2