### PR TITLE
Expose Issuer on authentication service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.5
+- Expose Issuer on StateBasedAuthenticationService
+
 # 3.0.4
 - Upgrade Stepup-saml-bundle to version 4.1.8 #31
 - Version pin Symfony 3.4 dependencies #31

--- a/src/Service/AuthenticationService.php
+++ b/src/Service/AuthenticationService.php
@@ -84,4 +84,11 @@ interface AuthenticationService
      * @return string
      */
     public function getNameId();
+
+    /**
+     * Get the entity id of the SP that is issuing the AuthNRequest
+     *
+     * @return string
+     */
+    public function getIssuer();
 }

--- a/src/Service/StateBasedAuthenticationService.php
+++ b/src/Service/StateBasedAuthenticationService.php
@@ -94,4 +94,12 @@ final class StateBasedAuthenticationService implements AuthenticationService
     {
         return $this->router->generate('gssp_saml_sso_return');
     }
+
+    /**
+     * @return string
+     */
+    public function getIssuer()
+    {
+        return $this->stateHandler->getRequestServiceProvider();
+    }
 }


### PR DESCRIPTION
The issuer will be used by the Azure MFA GSSP to conditionally alter the behaviour of the outgoing AuthNRequest.