### PR TITLE
Expose requester ids on authentication service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.6
+- Expose the Scoping -> RequesterIds on StateBasedAuthenticationService
+
 # 3.0.5
 - Expose Issuer on StateBasedAuthenticationService
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 3.0.6
+For this release the StateHandlerInterface and the AuthenticationService interface have been updated. If you implement 
+these interfaces yourself, please implement these methods in your concrete implementations.
+Use the bundles implementations as inspiration or, if you do not use them, leave them unimplemented logic wise.
+
 - Expose the Scoping -> RequesterIds on StateBasedAuthenticationService
 
 # 3.0.5

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,7 @@
   "autoload-dev": {
     "psr-4": {
       "Tests\\Surfnet\\GsspBundle\\": "tests/"
-    },
-    "files": [
-      "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php"
-    ]
+    }
   },
   "require": {
     "php": "^5.6 || >=7.2",

--- a/src/Service/AuthenticationService.php
+++ b/src/Service/AuthenticationService.php
@@ -91,4 +91,12 @@ interface AuthenticationService
      * @return string
      */
     public function getIssuer();
+
+    /**
+     * Returns the chain of requester ids originally saved from the
+     * actual authnrequest that instantiated the authentication.
+     *
+     * @return string[]
+     */
+    public function getScopingRequesterIds();
 }

--- a/src/Service/StateBasedAuthenticationService.php
+++ b/src/Service/StateBasedAuthenticationService.php
@@ -90,6 +90,14 @@ final class StateBasedAuthenticationService implements AuthenticationService
         return $this->stateHandler->getSubjectNameId();
     }
 
+    public function getScopingRequesterIds()
+    {
+        if (!$this->stateHandler->hasScopingRequesterIds()) {
+            return [];
+        }
+        return $this->stateHandler->getScopingRequesterIds();
+    }
+
     private function generateSSOreturnUrl()
     {
         return $this->router->generate('gssp_saml_sso_return');

--- a/src/Service/StateHandler.php
+++ b/src/Service/StateHandler.php
@@ -48,6 +48,8 @@ final class StateHandler implements StateHandlerInterface
     const RESPONSE_ERROR_SUB_CODE = 'error_response_sub_code';
     const RESPONSE_ERROR_MESSAGE = 'error_response_message';
 
+    const SCOPING_REQUESTER_IDS = 'scoping_requester_ids';
+
     private $store;
 
     public function __construct(ValueStore $store)
@@ -76,6 +78,7 @@ final class StateHandler implements StateHandlerInterface
             ->setRequestServiceProvider($authnRequest->getServiceProvider())
             ->setRelayState($relayState)
             ->set(self::NAME_ID, $authnRequest->getNameId())
+            ->set(self::SCOPING_REQUESTER_IDS, $authnRequest->getScopingRequesterIds())
             ->set(self::REQUEST_TYPE, self::REQUEST_TYPE_AUTHENTICATION)
         ;
     }
@@ -172,6 +175,16 @@ final class StateHandler implements StateHandlerInterface
     public function invalidate()
     {
         $this->store->clear();
+    }
+
+    public function getScopingRequesterIds()
+    {
+        return $this->store->get(self::SCOPING_REQUESTER_IDS);
+    }
+
+    public function hasScopingRequesterIds()
+    {
+        return $this->store->has(self::SCOPING_REQUESTER_IDS);
     }
 
     private function setRelayState($relayState)

--- a/src/Service/StateHandlerInterface.php
+++ b/src/Service/StateHandlerInterface.php
@@ -82,6 +82,11 @@ interface StateHandlerInterface
     public function getSubjectNameId();
 
     /**
+     * @return string[]
+     */
+    public function getScopingRequesterIds();
+
+    /**
      * Is the current request type registration flow?
      *
      * @return bool
@@ -109,6 +114,11 @@ interface StateHandlerInterface
      * @return bool
      */
     public function hasRequestId();
+
+    /**
+     * @return bool
+     */
+    public function hasScopingRequesterIds();
 
     /**
      * Invalidate and delete the full state with all attributes.

--- a/tests/Service/StateHandlerTest.php
+++ b/tests/Service/StateHandlerTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\GsspBundle\Service;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class StateHandlerTest extends TestCase
+{
+    /**
+     * @var StateHandler
+     */
+    private $handler;
+
+    /**
+     * @var ValueStore|m\Mock
+     */
+    private $valueStore;
+
+    protected function setUp(): void
+    {
+        $this->valueStore = m::mock(ValueStore::class);
+        $this->handler = new StateHandler($this->valueStore);
+    }
+
+    public function test_can_test_if_scoping_requester_ids_is_present()
+    {
+        $this->valueStore
+            ->shouldReceive('has')
+            ->with('scoping_requester_ids')
+            ->andReturnFalse();
+        $this->assertFalse($this->handler->hasScopingRequesterIds());
+    }
+
+    public function test_can_test_if_scoping_requester_ids_is_present_when_present()
+    {
+        $this->valueStore
+            ->shouldReceive('has')
+            ->with('scoping_requester_ids')
+            ->andReturnTrue();
+        $this->assertTrue($this->handler->hasScopingRequesterIds());
+    }
+
+    public function test_can_get_scoping_requester_ids()
+    {
+        $this->valueStore
+            ->shouldReceive('get')
+            ->with('scoping_requester_ids')
+            ->andReturn(['a', 'b', 'c']);
+        $this->assertEquals(['a', 'b', 'c'], $this->handler->getScopingRequesterIds());
+    }
+}


### PR DESCRIPTION
The state handle stores these ids in its value store. The service can be
used to retrieve them in the application.

This PR relates to: 
https://github.com/OpenConext/Stepup-Azure-MFA/pull/24
https://github.com/OpenConext/Stepup-saml-bundle/pull/97