### PR TITLE
Upgrade PHP dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "surfnet/stepup-gssp-bundle",
   "license": "Apache-2.0",
-  "description": "A Symfony 3 bundle (with SF 4 support) to aid the creation of GSSP (Generic SAML Step-up Provider) device support.",
+  "description": "A Symfony 5|6 bundle to aid the creation of GSSP (Generic SAML Step-up Provider) device support.",
   "type": "symfony-bundle",
   "autoload": {
     "psr-4": {
@@ -14,26 +14,29 @@
     }
   },
   "require": {
-    "php": "~7.2",
+    "php": "^8.1",
     "ext-openssl": "*",
     "beberlei/assert": "^3",
-    "sensio/framework-extra-bundle": "^5.4",
-    "symfony/monolog-bundle": "^3.6.0",
-    "surfnet/stepup-saml-bundle": "^5.0",
-    "symfony/dependency-injection": "^4.4",
-    "symfony/framework-bundle": "^4.4"
+    "symfony/monolog-bundle": "^3.8",
+    "surfnet/stepup-saml-bundle": "^6.0",
+    "symfony/dependency-injection": "^5.4|^6.3",
+    "symfony/framework-bundle": "^5.4|^6.3"
   },
   "require-dev": {
-    "behat/behat": "^3.5",
+    "behat/behat": "^3.13",
     "jakub-onderka/php-parallel-lint": "^1",
     "malukenho/docheader": "^0",
-    "mockery/mockery": "^1",
-    "phpmd/phpmd": "^2",
-    "phpunit/phpcov": "^6",
-    "phpunit/phpunit": "^8",
-    "sebastian/phpcpd": "^4",
-    "squizlabs/php_codesniffer": "^3",
-    "symfony/phpunit-bridge": "~4"
+    "mockery/mockery": "^1.5",
+    "overtrue/phplint": "*",
+    "phpmd/phpmd": "^2.13",
+    "phpstan/phpstan": "^1.10",
+    "phpstan/phpstan-symfony": "^1.3",
+    "phpunit/phpcov": "^8.2",
+    "phpunit/phpunit": "^9.6",
+    "sebastian/phpcpd": "^6.0",
+    "slevomat/coding-standard": "^8.13",
+    "squizlabs/php_codesniffer": "^3.7.1",
+    "symfony/phpunit-bridge": "^5.4|^6.3"
   },
   "scripts": {
     "test": [
@@ -78,6 +81,9 @@
     "phpunit-coverage": "vendor/bin/phpunit tests --coverage-php coverage/reports/unit.cov"
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "surfnet/stepup-gssp-bundle",
   "license": "Apache-2.0",
-  "description": "A Symfony 5|6 bundle to aid the creation of GSSP (Generic SAML Step-up Provider) device support.",
+  "description": "A Symfony 6 bundle to aid the creation of GSSP (Generic SAML Step-up Provider) device support.",
   "type": "symfony-bundle",
   "autoload": {
     "psr-4": {
@@ -14,13 +14,13 @@
     }
   },
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "ext-openssl": "*",
     "beberlei/assert": "^3",
     "symfony/monolog-bundle": "^3.8",
     "surfnet/stepup-saml-bundle": "^6.0",
-    "symfony/dependency-injection": "^5.4|^6.3",
-    "symfony/framework-bundle": "^5.4|^6.3"
+    "symfony/dependency-injection": "^6.4",
+    "symfony/framework-bundle": "^6.4"
   },
   "require-dev": {
     "behat/behat": "^3.13",
@@ -36,7 +36,7 @@
     "sebastian/phpcpd": "^6.0",
     "slevomat/coding-standard": "^8.13",
     "squizlabs/php_codesniffer": "^3.7.1",
-    "symfony/phpunit-bridge": "^5.4|^6.3"
+    "symfony/phpunit-bridge": "^6.4"
   },
   "scripts": {
     "test": [


### PR DESCRIPTION
Allowing Symfony 6.4
Require PHP 8.2

:warning: Note that some (dev) dependencies have been added but are not configured yet. Next PR will reorganize the way we run the QA scripts.
:warning: Builds are green, but only because they aren't actually running the QA tests ;)